### PR TITLE
avoid warning by forcing absolute imports:

### DIFF
--- a/Products/DCWorkflow/exportimport.py
+++ b/Products/DCWorkflow/exportimport.py
@@ -12,6 +12,7 @@
 ##############################################################################
 """DCWorkflow export / import support.
 """
+from __future__ import absolute_import
 
 import re
 from xml.dom.minidom import parseString


### PR DESCRIPTION
../Products.DCWorkflow/Products/DCWorkflow/exportimport.py:18: ImportWarning: Not importing directory '.../Products.DCWorkflow/Products/DCWorkflow/xml': missing __init__.py
  from xml.dom.minidom import parseString